### PR TITLE
Lo veo bien pero:

### DIFF
--- a/proxy_registrar.py
+++ b/proxy_registrar.py
@@ -91,7 +91,7 @@ class Handler(SocketServer.DatagramRequestHandler):
                     MeterLog(envio)
 
             else:
-                #busco si el usuario existe y envío el mensaje, si no, envío
+                #busco si el usuario existe y envío el mensaje, si no, "envío"
                 #"404 user not found"
                 user = str(line3[1])
                 if user in dicc_usuario:


### PR DESCRIPTION
He resaltado entre comillas lo de envío, porque realmente si el método no está reconocido o tienes un 404 user not found,  lo escribes en tu proxy pero no lo envías a ninguna parte y debería llegarle a tu cliente para que este fuera consciente de ello.
